### PR TITLE
CIF-1775: Fix GetMcId bad parsing

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,7 +144,7 @@ func (c *Client) GetMcId() (*DcmiGetMcIdResponse, error) {
 		// Accumulate the bytes received in the index until it
 		// is the same as the number of bytes expected
 		dataBuffer.WriteString(res.Data)
-		index += res.NumBytes
+		index += uint8(len(res.Data))
 		if res.NumBytes == index {
 			res.Data = dataBuffer.String()
 			lastChunkReceived = true


### PR DESCRIPTION
# Summary
NumBytes gets the total amount of bytes to read. The index variable was not being increased with the bytes read, but with the total bytes to read. This was fixed adding to the index variable the len of the content read

🤦‍♂ 🤦‍♂ 🤦‍♂ 🤦‍♂ 🤦‍♂ 